### PR TITLE
Add a new metric to for the number of active (spinning) disks

### DIFF
--- a/.homeycompose/capabilities/disksactive.json
+++ b/.homeycompose/capabilities/disksactive.json
@@ -1,0 +1,12 @@
+{
+    "type": "number",
+    "title": {
+        "en": "Disks active (spinning)"
+    },
+    "getable": true,
+    "setable": false,
+    "insights": false,
+    "decimals": 0,
+    "uiComponent": "sensor",
+    "icon": "/assets/capabilities/array.svg"
+}

--- a/.homeycompose/flow/conditions/disks-active-condition.json
+++ b/.homeycompose/flow/conditions/disks-active-condition.json
@@ -1,0 +1,21 @@
+{
+    "title": {
+        "en": "The number of active disks is !{{over|under}}"
+    },
+    "titleFormatted": {
+        "en": "The number of active disks is !{{over|under}} [[active-disks]]"
+    },
+    "hint": {
+        "en": "The number of active (spinning) disks is over or under a threshold"
+    },
+    "args": [
+        {
+            "type": "number",
+            "name": "active-disks",
+            "title": {
+                "en": "Active disks"
+            },
+            "example": 5
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -54,6 +54,25 @@ For each one of them you can trigger a flow. For example:
 
 You can do everything via flow cards or via API
 
+#### Active disks
+The app can report the number of active disks in the Unraid server via the metric **Disks active**. "Active" means the disk is spinning, "not active" means the disk is spun down (the motor is stopped).
+
+This metric can be used to control air conditioning. E.g. if your Unraid server regularly has long periods when no disks are spinning, you turn off the cooling or adjust the temperature setting to save power.
+
+This can be done with a flows similar to:
+
+_When_ **The number of active disks has changed** _and_ **The number of active disks is greater than 0**, _then_ **Turn on A/C**.
+
+_When_ **The number of active disks has changed** _and_ **The number of active disks is exactly 0**, _then_ **Turn off A/C**.
+
+##### The "Disks offset" setting
+
+This app uses `smartctl` to check which disks are active. It cannot currently distinguish between actual hard drives and SSDs, so the reported number includes both. SSDs are never "spun down", so they are always reported as active. 
+
+If your Unraid server has 10 hard drives and 2 SSDs, the app will report 12 active disks when all hard drives are spinning, and 2 active disks when all hard drives are spun down.
+
+If you want to exclude SSDs from the "disks active" metric, you can adjust the "Disks offset" setting. It should usually be set to a number equal to the number of SSDs in your Unraid server. This number will be subtracted from the "disks active" metric, ensuring the "disks active" metric reports zero when all hard drives are stopped.
+
 #### API Documentation
 
 ##### Operation List

--- a/app.json
+++ b/app.json
@@ -223,6 +223,28 @@
       },
       {
         "title": {
+          "en": "The number of active disks is !{{over|under}}"
+        },
+        "titleFormatted": {
+          "en": "The number of active disks is !{{over|under}} [[active-disks]]"
+        },
+        "hint": {
+          "en": "The number of active (spinning) disks is over or under a threshold"
+        },
+        "args": [
+          {
+            "type": "number",
+            "name": "active-disks",
+            "title": {
+              "en": "Active disks"
+            },
+            "example": 5
+          }
+        ],
+        "id": "disks-active-condition"
+      },
+      {
+        "title": {
           "en": "The file !{{exists|doesn't exist}}",
           "it": "Il file !{{esiste|non esiste}}",
           "fr": "Le fichier !{{existe|n'existe pas}}"
@@ -1578,6 +1600,35 @@
         ]
       },
       {
+        "id": "disks-active-is-changed",
+        "title": {
+          "en": "The number of active disks has changed"
+        },
+        "titleFormatted": {
+          "en": "The number of active disks has changed"
+        },
+        "hint": {
+          "en": "This flow is triggered when the number of active (spinning) disks has changed"
+        },
+        "tokens": [
+          {
+            "name": "active-disks",
+            "type": "number",
+            "title": {
+              "en": "Active disks"
+            },
+            "example": 5
+          }
+        ],
+        "args": [
+          {
+            "type": "device",
+            "name": "device",
+            "filter": "driver_id=unraid-driver"
+          }
+        ]
+      },
+      {
         "id": "docker-container-status-changed",
         "title": {
           "en": "Docker container online status changed",
@@ -1648,7 +1699,8 @@
         "uptime",
         "arrayinfo",
         "arrayused",
-        "cacheused"
+        "cacheused",
+        "disksactive"
       ],
       "platforms": [
         "local"
@@ -1790,6 +1842,18 @@
             "en": "Disable the Unraid server toggle when the device card is pressed",
             "it": "Disabilita l'interruttore del server Unraid quando viene premuta la scheda del dispositivo"
           }
+        },
+        {
+          "id": "disksOffset",
+          "type": "number",
+          "label": {
+            "en": "Disks offset"
+          },
+          "value": 0,
+          "min": 0,
+          "hint": {
+            "en": "If the number of active disks in Homey does not show zero when you know that the Unraid server's hard disks are all spun down; use this setting to adjust. E.g. if Homey shows 2 active disks when all disks are spun down, adjust this setting to 2. Usually this will be equal to the number of SSDs in your Unraid server. Default: 0"
+          }
         }
       ]
     }
@@ -1858,6 +1922,18 @@
         "it": "%"
       },
       "icon": "/assets/capabilities/cpu.svg"
+    },
+    "disksactive": {
+      "type": "number",
+      "title": {
+        "en": "Disks active (spinning)"
+      },
+      "getable": true,
+      "setable": false,
+      "insights": false,
+      "decimals": 0,
+      "uiComponent": "sensor",
+      "icon": "/assets/capabilities/array.svg"
     },
     "friendlyUptime": {
       "type": "string",

--- a/drivers/unraid-driver/device.ts
+++ b/drivers/unraid-driver/device.ts
@@ -34,6 +34,7 @@ class UnraidRemoteDevice extends Homey.Device {
       arrayUsageTriggerCard: this.homey.flow.getDeviceTriggerCard('array-usage-is-changed'),
       cacheUsageTriggerCard: this.homey.flow.getDeviceTriggerCard('cache-usage-is-changed'),
       ramUsageTriggerCard: this.homey.flow.getDeviceTriggerCard('ram-usage-is-changed'),
+      disksActiveTriggerCard: this.homey.flow.getDeviceTriggerCard('disks-active-is-changed'),
       dockerContainerStatusChangedTriggerCard: this.homey.flow.getDeviceTriggerCard('docker-container-status-changed')
     });
     let settings = await this.getSettings();
@@ -309,6 +310,7 @@ class UnraidRemoteDevice extends Homey.Device {
     this._updateArrayUsedCapability(0);
     this._updateCacheUsedCapability(0);
     this._updateRamUsedCapability(0);
+    this._updateDisksActiveCapability(0);
   }
 
   async _updateDeviceCapabilities(systemStats : ISystemStats, setInfo : boolean) : Promise<void>{
@@ -322,6 +324,7 @@ class UnraidRemoteDevice extends Homey.Device {
     if(systemStats.arrayUsage) this._updateArrayUsedCapability(systemStats.arrayUsage.percentUsed);
     if(systemStats.cacheUsage) this._updateCacheUsedCapability(systemStats.cacheUsage.percentUsed);
     if(systemStats.ramUsage) this._updateRamUsedCapability(systemStats.ramUsage.percentUsed);
+    if(systemStats.diskStatus) this._updateDisksActiveCapability(systemStats.diskStatus.disksSpinning);
     if(this._enableDockerMonitoring){
       this._flowTriggers?.triggerDockerContainerStatusChangedFlowCard(this, await this.containerList(), this.homey.app as UnraidRemoteApp);
     }
@@ -375,6 +378,15 @@ class UnraidRemoteDevice extends Homey.Device {
     const oldRamUsedValue : number = this.hasCapability('ramused') ? this.getCapabilityValue('ramused') : 0;
     this.setCapabilityValue("ramused", value);//.catch(this.error);
     if(oldRamUsedValue != value) this._flowTriggers?.triggerRamUsageFlowCard(this, value);
+  }
+
+  _updateDisksActiveCapability(rawValue: number): void {
+    const offset = this.getSetting('disksOffset')
+    const adjustedValue = (typeof offset === 'number' && !isNaN(offset)) ?
+     rawValue = Math.max(0, rawValue - offset) : rawValue;
+    const oldValue : number = this.hasCapability('disksactive') ? this.getCapabilityValue('disksactive') : 0;
+    this.setCapabilityValue("disksactive", adjustedValue);//.catch(this.error);
+    if(oldValue != adjustedValue) this._flowTriggers?.triggerDisksActiveFlowCard(this, adjustedValue);
   }
 
   async _turnOn(){
@@ -433,6 +445,9 @@ class UnraidRemoteDevice extends Homey.Device {
     }
     if (this.hasCapability('cpuused') === false) {
       await this.addCapability('cpuused');
+    }
+    if (this.hasCapability('disksactive') === false) {
+      await this.addCapability('disksactive');
     }
   }
 

--- a/drivers/unraid-driver/driver.compose.json
+++ b/drivers/unraid-driver/driver.compose.json
@@ -12,7 +12,8 @@
     "uptime",
     "arrayinfo",
     "arrayused",
-    "cacheused"
+    "cacheused",
+    "disksactive"
   ],
   "platforms": [
     "local"

--- a/drivers/unraid-driver/driver.flow.compose.json
+++ b/drivers/unraid-driver/driver.flow.compose.json
@@ -141,6 +141,28 @@
       "args": []
     },
     {
+      "id": "disks-active-is-changed",
+      "title": {
+        "en": "The number of active disks has changed"
+      },
+      "titleFormatted": {
+        "en": "The number of active disks has changed"
+      },
+      "hint": {
+        "en": "This flow is triggered when the number of active (spinning) disks has changed"
+      },
+      "tokens": [
+        {
+          "name": "active-disks",
+          "type": "number",
+          "title": {
+            "en": "Active disks"
+          },
+          "example": 5
+        }
+      ]
+    },
+    {
       "id": "docker-container-status-changed",
       "title": {
         "en": "Docker container online status changed",

--- a/drivers/unraid-driver/driver.settings.compose.json
+++ b/drivers/unraid-driver/driver.settings.compose.json
@@ -115,5 +115,17 @@
         "en": "Disable the Unraid server toggle when the device card is pressed",
         "it": "Disabilita l'interruttore del server Unraid quando viene premuta la scheda del dispositivo"
       }
+    },
+    {
+      "id": "disksOffset",
+      "type": "number",
+      "label": { 
+        "en": "Disks offset"
+      },
+      "value": 0,
+      "min": 0,
+      "hint": {
+        "en": "If the number of active disks in Homey does not show zero when you know that the Unraid server's hard disks are all spun down; use this setting to adjust. E.g. if Homey shows 2 active disks when all disks are spun down, adjust this setting to 2. Usually this will be equal to the number of SSDs in your Unraid server. Default: 0"
+      }
     }
 ]

--- a/drivers/unraid-driver/unraid-remote/UnraidRemote.ts
+++ b/drivers/unraid-driver/unraid-remote/UnraidRemote.ts
@@ -11,6 +11,7 @@ import { UserScript } from './utils/IUserScript';
 import { VirtualMachine } from './utils/IVirtualMachine';
 import { IVMRebootModes, IVMShutdownModes, VMState } from '@ridenui/unraid/dist/modules/vms/vm';
 import { File, FileManager, Share, WriteMode } from '../file-manager/FileManager';
+import { DisksInfo, LsblkResult, SmartctlResult } from './utils/Disks';
 
 class UnraidRemote {
     private _url: string;
@@ -162,7 +163,8 @@ class UnraidRemote {
             uptime: await this._getUptime(),
             arrayUsage: await this._getArrayInfo(),
             cacheUsage: await this._getCacheInfo(),
-            ramUsage: await this._getRamInfo()
+            ramUsage: await this._getRamInfo(),
+            diskStatus: await this._getDisks()
         };
         return systemInfo;
     }
@@ -662,6 +664,34 @@ class UnraidRemote {
             };
             return cpuUsage;
         } catch(error){
+            return undefined;
+        }
+    }
+
+    private async _getDisks(): Promise<DisksInfo | undefined> {
+        try {
+            const lsblkResult = await this._unraid.system.lsblk() as LsblkResult;
+            const disks = lsblkResult.blockdevices.filter(b => b.type === 'disk');
+
+            const smartctlPromises: Promise<unknown>[] = [];
+
+            for (const disk of disks) {
+                // `-n standby` prevents smartctl from spinning up the disk if it is stopped.
+                smartctlPromises.push(this._unraid.system.smartctl({ deviceName: `-n standby /dev/${disk.name}`, all: false}));
+            }
+            const smartctlResults = await Promise.all(smartctlPromises) as SmartctlResult[];
+
+            // The number of disks that could be queried and are not spun down
+            const successCount = smartctlResults.filter(s => s.smartctl.exit_status === 0).length;
+
+            // The number of disks with exist status 2. This appears to indicate the number of spun down disks
+            const error2Count = smartctlResults.filter(s => s.smartctl.exit_status === 2).length;
+
+            return {
+                disks: successCount + error2Count,
+                disksSpinning: successCount
+            }
+        } catch (error) {
             return undefined;
         }
     }

--- a/drivers/unraid-driver/unraid-remote/triggers/UnraidRemoteFlowTrigger.ts
+++ b/drivers/unraid-driver/unraid-remote/triggers/UnraidRemoteFlowTrigger.ts
@@ -7,6 +7,7 @@ interface DeviceTriggerCards {
     arrayUsageTriggerCard: FlowCardTriggerDevice
     cacheUsageTriggerCard: FlowCardTriggerDevice
     ramUsageTriggerCard: FlowCardTriggerDevice
+    disksActiveTriggerCard: FlowCardTriggerDevice
     dockerContainerStatusChangedTriggerCard : FlowCardTriggerDevice
 }
 
@@ -16,6 +17,7 @@ class UnraidRemoteFlowTrigger {
     private _cacheUsageIsChangedTriggerCard : FlowCardTriggerDevice;
     private _ramUsageIsChangedTriggerCard : FlowCardTriggerDevice;
     private _dockerContainerStatusChangedTriggerCard : FlowCardTriggerDevice;
+    private _disksActiveTriggerCard: FlowCardTriggerDevice;
     private _dockerMonitor : DockerMonitor;
 
     constructor(triggers : DeviceTriggerCards){
@@ -24,6 +26,7 @@ class UnraidRemoteFlowTrigger {
         this._cacheUsageIsChangedTriggerCard = triggers.cacheUsageTriggerCard;
         this._ramUsageIsChangedTriggerCard = triggers.ramUsageTriggerCard;
         this._dockerContainerStatusChangedTriggerCard = triggers.dockerContainerStatusChangedTriggerCard;
+        this._disksActiveTriggerCard = triggers.disksActiveTriggerCard;
         this._dockerMonitor = new DockerMonitor();
     }
 
@@ -41,6 +44,10 @@ class UnraidRemoteFlowTrigger {
 
     triggerRamUsageFlowCard(device: Homey.Device,ramUsage: number){
         this._ramUsageIsChangedTriggerCard?.trigger(device, { 'usage-percent': ramUsage }, undefined);
+    }
+
+    triggerDisksActiveFlowCard(device: Homey.Device, disksActive: number) {
+        this._disksActiveTriggerCard?.trigger(device, { 'active-disks': disksActive }, undefined);
     }
     
     async triggerDockerContainerStatusChangedFlowCard(device: Homey.Device, containers: Container[], appInstance? : UnraidRemoteApp){

--- a/drivers/unraid-driver/unraid-remote/utils/Disks.ts
+++ b/drivers/unraid-driver/unraid-remote/utils/Disks.ts
@@ -1,0 +1,79 @@
+/**
+ * The object returned when calling lsblk
+ */
+export interface LsblkResult {
+    blockdevices: {
+        /**
+         * Device name, e.g. "sda"
+         */
+        name: string;
+
+        type: "loop" | "disk"
+
+        /**
+         * Disk size, e.g. "12.7T" or "20G"
+         */
+        size: string;
+    }[];
+}
+
+/**
+ * The object returned when calling smartctl
+ */
+export interface SmartctlResult {
+    json_format_version: unknown;
+    
+    smartctl: {
+
+        /**
+         * Error/warning messages.
+         * Not defined if exit_status is 0
+         */
+        messages?: {
+            string: string;
+            severity: "error" | "information";
+        }[];
+
+        /**
+         * Exit code. Examples:
+         * 0: Success
+         * 1: Unknown USB bridge
+         * 2: Device is in STANDBY mode
+         */
+        exit_status: number;
+    };
+    
+    local_time: unknown;
+    
+    /**
+     * Device info. Not included if device enumeration fails.
+     * E.g. if unknown device type (USB thumb drive)
+     */
+    device?: {
+        /**
+         * Device name, e.g. "/dev/sdc"
+         */
+        name: string;
+
+        /**
+         * E.g. "/dev/sdc [SAT]"
+         */
+        info_name: string;
+
+        type: "sat" | "scsi" | "nvme";
+
+        protocol: "ATA" | "SCSI" | "NVMe";
+    }
+}
+
+export interface DisksInfo {
+    /**
+     * The total number of disks detected in the system
+     */
+    disks: number;
+
+    /**
+     * The number of disks that are active (spinning)
+     */
+    disksSpinning: number;
+}

--- a/drivers/unraid-driver/unraid-remote/utils/ISystemStats.ts
+++ b/drivers/unraid-driver/unraid-remote/utils/ISystemStats.ts
@@ -1,5 +1,6 @@
 import { IDiskFreeReturn, ILoadAverage, IUptime } from '@ridenui/unraid/dist/modules/system/extensions';
 import { CPUUsage } from '@ridenui/unraid/dist/modules/system/extensions/cpu';
+import { DisksInfo } from './Disks';
 
 /* CPU Properties */
 interface ICPUUsage {
@@ -33,6 +34,7 @@ interface ISystemStats {
     ramUsage: IMemoryUsage | undefined;
     memoryUsage?: ILoadAverage | undefined;
     diskUsage?: IDiskFreeReturn[] | undefined;
+    diskStatus?: DisksInfo;
 }
 
 interface ISSHCommandOutput {


### PR DESCRIPTION
This adds a new metric to for the number of active (spinning) disks, as well as flow triggers for changes to this value.

The implementation uses existing capabilities from the `@ridenui/unraid` package:
* `lsblk` is used to get the list of all "block devices"
* Each of these devices is queried with `smartctl` to check its status. 
* The exit code from each `smartctl` call is used to indicate whether or not each disk is active.

The new setting "Disks offset" is used to adjust the reported metric. The raw metric includes both SSDs and hard drives. To make the metric represent hard drives only, the user can set this setting equal to the number of SSDs. This will be subtracted from the raw value in the reported metric.

I have not included any French or Italian translations for new strings, as I don't speak either of these languages. I don't want to risk introducing machine translations as I don't know your policy on that.

<img width="325" height="535" alt="disksactive1" src="https://github.com/user-attachments/assets/e05c68f7-5be6-412f-8ee2-5bd1da4ae6d4" />
<img width="325" height="541" alt="disksactive2" src="https://github.com/user-attachments/assets/64eb2613-b760-4628-a40e-d0a0f617d856" />
<img width="325" height="541" alt="disksactive3" src="https://github.com/user-attachments/assets/f8cbafdd-4bdf-46b3-99b9-e53d55c31af1" />
